### PR TITLE
Added RGB8 pixel_format for colored visualization in rviz2

### DIFF
--- a/config/chameleon.cfg
+++ b/config/chameleon.cfg
@@ -42,6 +42,12 @@ line3_selector enum "DigitalIOControl/LineSelector"
 line3_linemode enum "DigitalIOControl/LineMode"
 
 #
+# --------- image format control
+#
+
+pixel_format enum "ImageFormatControl/PixelFormat"
+
+#
 # -------- acquisition control
 #
 

--- a/launch/chameleon.launch.py
+++ b/launch/chameleon.launch.py
@@ -11,6 +11,7 @@ camera_params = {
     # set parameters defined in chameleon.cfg    
     'gain_auto': 'Continuous',
     'exposure_auto': 'Continuous',
+    'pixel_format': 'RGB8', # 'BayerRG8, 'RGB8' or 'Mono8'
     'frame_rate_continous': True,
     'frame_rate': 100.0,
     'trigger_mode': 'Off',

--- a/src/camera_driver.cpp
+++ b/src/camera_driver.cpp
@@ -450,6 +450,9 @@ static std::string flir_to_ros_encoding(
     case flir_spinnaker_common::pixel_format::BayerRG8:
       return (sensor_msgs::image_encodings::BAYER_RGGB8);
       break;
+    case flir_spinnaker_common::pixel_format::RGB8:
+      return (sensor_msgs::image_encodings::RGB8);
+      break;
     case flir_spinnaker_common::pixel_format::Mono8:
       return (sensor_msgs::image_encodings::MONO8);
       break;


### PR DESCRIPTION
This PR adds support for the RGB8 pixel format.

With the current BayerRG8 format, images in rviz2 are displayed as grayscale, even though they should be colored.

Depends on:
https://github.com/berndpfrommer/flir_spinnaker_common/pull/1