### PR TITLE
Add configuration and launch files for GigE Blackfly S 

### DIFF
--- a/config/blackfly_s_gige.cfg
+++ b/config/blackfly_s_gige.cfg
@@ -1,0 +1,100 @@
+#
+# config file for Blackfly S cameras with Gigabit Ethernet
+#
+# This file maps the ros parameters to the corresponding "nodes" in the camera.
+# The question remains what the valid values are for the enum types. For that
+# use the spinnaker GUI (spinview), or dump the nodemap by setting the
+# "dump_node_map" parameter in the driver. Also setting the "debug" param helps.
+#
+# NOTE: !!!!  THE ORDER OF PARAMETER DEFINITION MATTERS !!!!
+# On node startup, the parameters will be declared and initialized
+# in the order listed here. For instance you must list
+# the enum "exposure_auto" before the float "exposure_time" because on
+# startup, "exposure_auto" must first be set to "Off" before
+# "exposure_time" can be set, or else the camera refuses to set
+# the exposure time.
+#
+
+#
+# -------- analog control
+#
+
+gain_auto       enum  "AnalogControl/GainAuto"
+gain            float "AnalogControl/Gain"
+
+#
+# -------- digital IO control
+#
+
+# black wire: opto-isolated input
+line0_selector enum "DigitalIOControl/LineSelector"
+
+# white wire: opto-isolated output
+line1_selector enum "DigitalIOControl/LineSelector"
+# valid values: "Input", "Output"
+line1_linemode enum "DigitalIOControl/LineMode"
+
+# red wire: non-isolated input/output and power output
+line2_selector enum "DigitalIOControl/LineSelector"
+line2_v33enable bool "DigitalIOControl/V3_3Enable"
+
+# green wire: aux voltage input and non-isolated input
+line3_selector enum "DigitalIOControl/LineSelector"
+# valid values: "Input", "Output"
+line3_linemode enum "DigitalIOControl/LineMode"
+
+#
+# -------- acquisition control
+#
+
+exposure_auto   enum  "AcquisitionControl/ExposureAuto"
+exposure_time   float "AcquisitionControl/ExposureTime"
+
+frame_rate_enable bool  "AcquisitionControl/AcquisitionFrameRateEnable"
+frame_rate        float "AcquisitionControl/AcquisitionFrameRate"
+
+# valid values are e.g. "FrameStart", "AcquisitionStart", "FrameBurstStart"
+trigger_selector enum "AcquisitionControl/TriggerSelector"
+
+# valid values are "On" and "Off"
+trigger_mode  enum "AcquisitionControl/TriggerMode"
+
+# valid values are "Line<0,1,2>", "UserOutput<0,1,2>", "Counter<0,1><Start/End>",
+# "LogicBlock<0,1>
+trigger_source  enum "AcquisitionControl/TriggerSource"
+
+# value >= 9 
+trigger_delay float "AcquisitionControl/TriggerDelay"
+
+# valid values: "Off" and "ReadOut"
+trigger_overlap enum "AcquisitionControl/TriggerOverlap"
+
+#
+# --------- chunk control
+#
+
+chunk_mode_active bool "ChunkDataControl/ChunkModeActive"
+
+# valid values: "FrameID"
+chunk_selector_frame_id enum "ChunkDataControl/ChunkSelector"
+chunk_enable_frame_id bool "ChunkDataControl/ChunkEnable"
+
+# valid values: "ExposureTime"
+chunk_selector_exposure_time enum "ChunkDataControl/ChunkSelector"
+chunk_enable_exposure_time bool "ChunkDataControl/ChunkEnable"
+
+# valid values: "Gain"
+chunk_selector_gain enum "ChunkDataControl/ChunkSelector"
+chunk_enable_gain bool "ChunkDataControl/ChunkEnable"
+
+# valid values: "Timestamp"
+chunk_selector_timestamp enum "ChunkDataControl/ChunkSelector"
+chunk_enable_timestamp bool "ChunkDataControl/ChunkEnable"
+
+#
+# --------- transport layer control (GigE-specific)
+#
+
+# default: 1400
+# set to 9000 to enable jumbo frames, ensure NIC MTU set >= 9000
+gev_scps_packet_size int "TransportLayerControl/GigEVision/GevSCPSPacketSize"

--- a/launch/blackfly_s_gige.launch.py
+++ b/launch/blackfly_s_gige.launch.py
@@ -1,0 +1,49 @@
+from launch_ros.actions import Node
+from launch.substitutions import LaunchConfiguration as LaunchConfig
+from launch.actions import DeclareLaunchArgument as LaunchArg
+from launch import LaunchDescription
+from ament_index_python.packages import get_package_share_directory
+
+camera_params = {
+    'debug': False,
+    'compute_brightness': False,
+    'dump_node_map': False,
+    # set parameters defined in blackfly_s_gige.cfg    
+    'gain_auto': 'Continuous',
+    'exposure_auto': 'Continuous',
+    'frame_rate_auto': 'Off',
+    'frame_rate': 20.0,
+    'frame_rate_enable': True,
+    'trigger_mode': 'Off',
+    'chunk_mode_active': True,
+    'chunk_selector_frame_id': 'FrameID',
+    'chunk_enable_frame_id': True,
+    'chunk_selector_exposure_time': 'ExposureTime',
+    'chunk_enable_exposure_time': True,
+    'chunk_selector_gain': 'Gain',
+    'chunk_enable_gain': True,
+    'chunk_selector_timestamp': 'Timestamp',
+    'chunk_enable_timestamp': True,
+    'gev_scps_packet_size': 9000,
+    }
+
+def generate_launch_description():
+    """launch blackfly_s camera node."""
+    flir_dir = get_package_share_directory('flir_spinnaker_ros2')
+    config_dir = flir_dir + '/config/'
+    name_arg = LaunchArg('camera_name', default_value='blackfly_s',
+                         description='camera name')
+    serial_arg = LaunchArg('serial', default_value="'20435008'",
+                         description='serial number')
+    print([LaunchConfig('serial'),'_'])
+    node = Node(package='flir_spinnaker_ros2',
+                executable='camera_driver_node',
+                output='screen',
+                name=[LaunchConfig('camera_name')],
+                parameters=[camera_params,
+                        {'parameter_file': config_dir + 'blackfly_s_gige.cfg',
+                         'serial_number': [LaunchConfig('serial')],
+                        }],
+                remappings=[('~/control', '/exposure_control/control'),],
+    )
+    return LaunchDescription([name_arg, serial_arg, node])


### PR DESCRIPTION
This pull request adds the GigE Vision-specific parameter to enable jumbo frames from Blackfly S cameras, as well as a launch file to set it. These cameras support a max of 9000, as do most NICs from the last decade or so. 

Currently, this requires the camera have a compatible IP address already (from DHCP, persistent IP, or "Auto Force IP" set via SpinView).

Tested against BFS-PGE-23S3C cameras in Foxy.