### PR TITLE
Use sensor time

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,13 +155,34 @@ time stamp syncing) and
 
 ### Time stamps
 
+By default the driver will set the ROS header time stamp to be the
+time when the image was delivered by the SDK. Such time stamps are not
+very precise and may lag depending on host CPU load. However the
+driver has a feature to use the much more accurate sensor-provided
+camera time stamps. These are then converted to ROS time stamps by
+estimating the offset between ROS and sensor time stamps via a simple
+moving average. For the adjustment to work
+*the camera must be configured to send time stamps*, and the
+``adjust_timestamp`` flag must be set to true, and the relevant field
+in the "chunk" must be populated by the camera. For the Blackfly S
+the parameters look like this:
+
+```
+    'adjust_timestamp': True,
+    'chunk_mode_active': True,
+    'chunk_selector_timestamp': 'Timestamp',
+    'chunk_enable_timestamp': True,
+```
+
 When running hardware synchronized cameras in a stereo configuration
 two drivers will need to be run, one for each camera. This will mean
 however that their published ROS header time stamps are *not*
 identical which in turn may prevent down-stream ROS nodes from recognizing the
 images as being hardware synchronized. You can use the
 [cam_sync_ros2 node](https://github.com/berndpfrommer/cam_sync_ros2)
-to force the time stamps to be aligned.
+to force the time stamps to be aligned. In this scenario it is
+mandatory to configure the driver to adjust the ROS time stamps as
+described above.
 
 
 ### Automatic exposure

--- a/include/flir_spinnaker_ros2/camera_driver.h
+++ b/include/flir_spinnaker_ros2/camera_driver.h
@@ -24,6 +24,7 @@
 #include <deque>
 #include <image_meta_msgs_ros2/msg/image_meta_data.hpp>
 #include <image_transport/image_transport.hpp>
+#include <limits>
 #include <map>
 #include <memory>
 #include <rclcpp/rclcpp.hpp>
@@ -65,6 +66,7 @@ private:
   bool setInt(const std::string & nodeName, int v);
   bool setBool(const std::string & nodeName, bool v);
   bool readParameterFile();
+  rclcpp::Time getAdjustedTimeStamp(uint64_t t, int64_t sensorTime);
 
   void run();  // thread
 
@@ -90,7 +92,10 @@ private:
   bool debug_{false};
   bool computeBrightness_{false};
   double acquisitionTimeout_{3.0};
+  bool adjustTimeStamp_{false};
   uint32_t currentExposureTime_{0};
+  double averageTimeDifference_{std::numeric_limits<double>::quiet_NaN()};
+  int64_t baseTimeOffset_{0};
   float currentGain_{std::numeric_limits<float>::lowest()};
   std::shared_ptr<flir_spinnaker_common::Driver> driver_;
   std::shared_ptr<camera_info_manager::CameraInfoManager> infoManager_;

--- a/launch/blackfly_s.launch.py
+++ b/launch/blackfly_s.launch.py
@@ -24,6 +24,7 @@ from ament_index_python.packages import get_package_share_directory
 camera_params = {
     'debug': False,
     'compute_brightness': False,
+    'adjust_timestamp': True,
     'dump_node_map': False,
     # set parameters defined in blackfly_s.cfg
     'gain_auto': 'Continuous',

--- a/launch/stereo_synced.launch.py
+++ b/launch/stereo_synced.launch.py
@@ -26,6 +26,7 @@ camera_params = {
     'debug': False,
     'compute_brightness': True,
     'dump_node_map': False,
+    'adjust_timestamp': True,
     'gain_auto': 'Off',
     'gain': 0,
     'exposure_auto': 'Off',

--- a/src/camera_driver.cpp
+++ b/src/camera_driver.cpp
@@ -539,7 +539,7 @@ void CameraDriver::doPublish(const ImageConstPtr & im)
 
   const std::string encoding = flir_to_ros_encoding(im->pixelFormat_);
 
-  if (count_subscribers(pub_.getTopic()) > 0) {
+  if (pub_.getNumSubscribers() > 0) {
     sensor_msgs::msg::CameraInfo::UniquePtr cinfo(
       new sensor_msgs::msg::CameraInfo(cameraInfoMsg_));
     // will make deep copy. Do we need to? Probably...


### PR DESCRIPTION
This PR does two things:
- adds a flag "adjust_timestamp" that will leverage the sensor-provided time stamps for more accurate header stamps. 
- fixes a bug where subscription to camerainfo alone would not cause the message to be published.