### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ Software:
   what the continuous integration builds are using)
 
 The code compiles under Ubuntu 22.04 / Humble but has not been tested
-yet with real hardware.
+thoroughly with real hardware. Currently known to work with Blackfly S (USB3)
+using Spinnaker 2.6.0.157.
+
 
 ## Features
 


### PR DESCRIPTION
Was able to get the driver working on Ubuntu 22.04 with Humble and Spinnaker 2.6.0.157. Had some issues using newer Spinnaker versions.