### PR TITLE
Sources spinnaker when installed from flir_common

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,8 @@ foreach(pkg ${ROS2_DEPENDENCIES})
   find_package(${pkg} REQUIRED)
 endforeach()
 
+ament_environment_hooks(findshared.sh.in)
+
 ament_auto_find_build_dependencies(REQUIRED ${ROS2_DEPENDENCIES})
 
 ament_auto_add_library(camera_driver SHARED

--- a/findshared.sh.in
+++ b/findshared.sh.in
@@ -1,0 +1,3 @@
+#!/bin/bash
+var=$(find ~/ -type d -path "*/build/flir_spinnaker_common/opt/spinnaker/lib")
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:"$var"


### PR DESCRIPTION
Following the PR from [flir_spinnaker_common](https://github.com/berndpfrommer/flir_spinnaker_common/pull/3)